### PR TITLE
Fix incorrect import path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ php artisan set:pathao-courier
 Add the Facade before using
 
 ```php
-use Enan\PathaoCourier\Facade\PathaoCourier;
+use Enan\PathaoCourier\Facades\PathaoCourier;
 ```
 
 > For the POST type response the required validation are mentioned before the function like <required, string> So here the value should be required and string


### PR DESCRIPTION
The folder structure is Facades, but the README uses Facade, which causes confusion during installation to new developers. This PR updates the import path in the documentation to match the actual directory structure.